### PR TITLE
feat(ai): extend label suggestions with pull request descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,20 +59,28 @@ pnpm dev suggest-labels
 pnpm dev help
 ```
 
-## AI-Powered Label Suggestions
+## AI-Powered Label and Description Suggestions
 
-The `suggest-labels` feature uses artificial intelligence to analyze pull requests and automatically suggest appropriate labels. This feature analyzes:
+The `suggest-labels` feature uses artificial intelligence to analyze pull requests and automatically suggest appropriate labels and descriptions. This feature analyzes:
 
 - Pull request title and description
 - Files that have been changed
 - Existing labels in the repository
+- Code changes and their context
 
 To use this feature:
 
 1. Set your OpenAI API key in the `OPENAI_API_KEY` environment variable.
 2. Run the command `pnpm dev suggest-labels` or select "Suggest labels for a pull request" in interactive mode.
 3. Select a repository and then choose a pull request to analyze.
-4. The AI will analyze the changes and suggest appropriate labels with explanations.
-5. You can review and apply the suggested labels to the selected pull request.
+4. The AI will analyze the pull request content and suggest:
+   - Appropriate labels with explanations and confidence scores
+   - A comprehensive description that summarizes the changes
+5. You can review and apply both the suggested labels and description to the pull request.
 
-This feature is especially useful for large teams where automating the categorization of pull requests can significantly improve workflow efficiency.
+This feature is especially useful for:
+
+- Large teams where automating PR categorization can improve workflow efficiency
+- Maintaining consistent PR descriptions across the project
+- Ensuring important changes are properly documented
+- Saving time on manual PR reviews and documentation

--- a/docs/guide/interactive-mode.md
+++ b/docs/guide/interactive-mode.md
@@ -76,7 +76,7 @@ When selecting "Remove labels from a repository", the interactive mode will:
 
 This is useful for cleaning up repositories by removing outdated, duplicate, or unwanted labels.
 
-## Interactively Suggesting Labels for Pull Requests
+## Interactively Suggesting Labels and Descriptions for Pull Requests
 
 When selecting "Suggest labels for a pull request", the interactive mode will:
 
@@ -93,22 +93,37 @@ When selecting "Suggest labels for a pull request", the interactive mode will:
      #51: Refactor GitHub API interaction
    ```
 6. Analyze the pull request content using AI
-7. Display label suggestions with confidence scores and explanations:
+7. Display suggestions with confidence scores:
 
    ```
-   Here are the suggested labels for this pull request:
+   Here are the suggestions for this pull request:
 
+   Suggested Labels:
    [EXISTING] documentation (Confidence: 95%)
       Reason: This PR primarily updates documentation for CLI commands
 
    [NEW] user-guide (Confidence: 80%)
       Reason: The changes focus specifically on user-facing guide information
+
+   Suggested Description:
+   Confidence: 90%
+   This pull request updates the CLI documentation to include detailed information about
+   command usage and interactive mode features. The changes include:
+   - Enhanced command descriptions
+   - New examples for each command
+   - Updated interactive mode workflow
+   - Added troubleshooting section
    ```
 
-8. Ask if you want to apply the suggested labels to the pull request
-9. Apply the selected labels if confirmed
+8. Ask if you want to apply the suggested changes to the pull request
+9. Apply both the selected labels and the suggested description if confirmed
 
-This feature streamlines the process of labeling pull requests by using AI to analyze content and suggest appropriate labels, saving time and ensuring consistent categorization.
+This feature streamlines the process of documenting and categorizing pull requests by using AI to:
+
+- Analyze content and suggest appropriate labels
+- Generate comprehensive descriptions that capture the essence of changes
+- Save time on manual documentation
+- Maintain consistent PR documentation across the project
 
 ## Benefits of Interactive Mode
 

--- a/src/commands/suggest-labels.ts
+++ b/src/commands/suggest-labels.ts
@@ -1,9 +1,51 @@
 import inquirer from 'inquirer';
 import ora from 'ora';
+import fs from 'fs';
+import path from 'path';
 import { GitHubManager } from '@/lib/github';
 import { logger } from '@/utils/logger';
 import { PublicError, OpenAIError, RateLimitError } from '@/utils/errors';
 import { openAIService } from '@/lib/openai';
+
+/**
+ * Gets the PR template content from the repository
+ */
+async function getPRTemplate(
+  github: GitHubManager,
+  repoFullName: string
+): Promise<string | undefined> {
+  try {
+    const [owner, repo] = repoFullName.split('/');
+    const templatePaths = [
+      '.github/PULL_REQUEST_TEMPLATE.md',
+      '.github/pull_request_template.md',
+      'PULL_REQUEST_TEMPLATE.md',
+      'pull_request_template.md',
+    ];
+
+    for (const templatePath of templatePaths) {
+      try {
+        const { data } = await github.octokit.repos.getContent({
+          owner,
+          repo,
+          path: templatePath,
+        });
+
+        if ('content' in data) {
+          const content = Buffer.from(data.content, 'base64').toString('utf-8');
+          return content;
+        }
+      } catch (error) {
+        continue; // Try next template path
+      }
+    }
+
+    return undefined;
+  } catch (error) {
+    logger.warning('Could not fetch PR template, proceeding without it.');
+    return undefined;
+  }
+}
 
 /**
  * Suggest labels for a pull request using AI
@@ -11,7 +53,7 @@ import { openAIService } from '@/lib/openai';
  */
 export async function suggestLabelsAction(token?: string): Promise<void> {
   try {
-    const spinner = ora('Starting AI label suggestion...').start();
+    const spinner = ora('Starting AI suggestion analysis...').start();
     const github = new GitHubManager(token);
     spinner.succeed();
 
@@ -50,15 +92,27 @@ export async function suggestLabelsAction(token?: string): Promise<void> {
     const prDetails = await github.getPullRequestDetails(repoFullName, selectedPR.number);
     spinner.succeed();
 
-    // Analyze PR and suggest labels
+    // Get PR template if available
+    spinner.text = 'Checking for PR template...';
+    spinner.start();
+    const prTemplate = await getPRTemplate(github, repoFullName);
+    if (prTemplate) {
+      spinner.succeed('Found PR template');
+    } else {
+      spinner.info('No PR template found, proceeding without it');
+    }
+
+    // Analyze PR and suggest labels and description
     spinner.text = 'Analyzing pull request with AI...';
     spinner.start();
-    const suggestions = await openAIService.suggestLabels(prDetails, labels);
+    const suggestions = await openAIService.suggestPRContent(prDetails, labels, prTemplate);
     spinner.succeed();
 
     // Display suggestions
-    logger.info('\nHere are the suggested labels for this pull request:');
-    suggestions.forEach(suggestion => {
+    logger.info('\nHere are the suggestions for this pull request:');
+
+    logger.info('\nSuggested Labels:');
+    suggestions.labels.forEach(suggestion => {
       const status = suggestion.isNew ? '[NEW]' : '[EXISTING]';
       const confidence = `(Confidence: ${suggestion.confidence}%)`;
       logger.info(`${status} ${suggestion.name} ${confidence}`);
@@ -66,28 +120,54 @@ export async function suggestLabelsAction(token?: string): Promise<void> {
       logger.info('');
     });
 
-    // Ask if user wants to apply labels
+    logger.info('\nSuggested Description:');
+    logger.info('\nEnglish version:');
+    logger.info(`Confidence: ${suggestions.description.en.confidence}%`);
+    logger.info(suggestions.description.en.content);
+    logger.info('\nPolish version:');
+    logger.info(`Confidence: ${suggestions.description.pl.confidence}%`);
+    logger.info(suggestions.description.pl.content);
+    logger.info('');
+
+    // Ask if user wants to apply changes
     const { shouldApply } = await inquirer.prompt([
       {
         type: 'confirm',
         name: 'shouldApply',
-        message: 'Would you like to apply these labels to the pull request?',
+        message: 'Would you like to apply these changes to the pull request?',
         default: true,
       },
     ]);
 
     if (shouldApply) {
-      spinner.text = 'Applying labels to pull request...';
+      const { language } = await inquirer.prompt<{ language: 'en' | 'pl' }>([
+        {
+          type: 'list',
+          name: 'language',
+          message: 'Which language version would you like to use?',
+          choices: [
+            { name: 'English', value: 'en' },
+            { name: 'Polish', value: 'pl' },
+          ],
+        },
+      ]);
+
+      spinner.text = 'Applying changes to pull request...';
       spinner.start();
 
       // Filter out new labels if needed
-      const labelsToApply = suggestions.map(s => s.name);
+      const labelsToApply = suggestions.labels.map(s => s.name);
 
-      await github.addLabelsToPullRequest(repoFullName, selectedPR.number, labelsToApply);
+      // Update PR description and labels
+      await github.updatePullRequest(repoFullName, selectedPR.number, {
+        body: suggestions.description[language].content,
+        labels: labelsToApply,
+      });
+
       spinner.succeed();
-      logger.success('Labels have been successfully applied to the pull request!');
+      logger.success('Changes have been successfully applied to the pull request!');
     } else {
-      logger.info('No labels were applied.');
+      logger.info('No changes were applied.');
     }
   } catch (error) {
     if (error instanceof PublicError) {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -411,6 +411,43 @@ class GitHubManager {
       );
     }
   }
+
+  /**
+   * Updates a pull request with new description and/or labels
+   */
+  async updatePullRequest(
+    repoFullName: string,
+    pullNumber: number,
+    updates: {
+      body?: string;
+      labels?: string[];
+    }
+  ): Promise<void> {
+    try {
+      const [owner, repo] = repoFullName.split('/');
+
+      // Update PR description and labels
+      await this.octokit.pulls.update({
+        owner,
+        repo,
+        pull_number: pullNumber,
+        body: updates.body,
+      });
+
+      if (updates.labels) {
+        await this.octokit.issues.setLabels({
+          owner,
+          repo,
+          issue_number: pullNumber,
+          labels: updates.labels,
+        });
+      }
+    } catch (error) {
+      throw new PublicError(
+        `Failed to update pull request: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
 }
 
 export { GitHubManager };

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -3,8 +3,7 @@ import { PublicError, OpenAIError, RateLimitError } from '@/utils/errors';
 import { logger } from '@/utils/logger';
 import { PullRequestDetails, GithubLabel } from '@/types';
 import { zodResponseFormat } from 'openai/helpers/zod';
-import { z } from 'zod';
-import { getLabelSuggestionPrompt } from '@/templates/prompts';
+import { labelSuggestionSchema, prSuggestionSchema } from '@/schemas/pr-suggestions';
 
 /**
  * Interface for the label suggestion response
@@ -14,6 +13,23 @@ export interface LabelSuggestion {
   description: string | null;
   confidence: number; // 0-100
   isNew: boolean; // if true, this label doesn't exist in the repository
+}
+
+/**
+ * Interface for the PR suggestion response
+ */
+export interface PRSuggestion {
+  labels: LabelSuggestion[];
+  description: {
+    en: {
+      content: string;
+      confidence: number;
+    };
+    pl: {
+      content: string;
+      confidence: number;
+    };
+  };
 }
 
 /**
@@ -35,8 +51,6 @@ export class OpenAIService {
 
   /**
    * Generates a summary of a pull request for AI analysis
-   * @param pr The pull request details
-   * @returns A string summary of the pull request
    */
   private generatePRSummary(pr: PullRequestDetails): string {
     const fileChanges = pr.files
@@ -56,15 +70,13 @@ ${fileChanges}
   }
 
   /**
-   * Suggests labels for a pull request based on its content
-   * @param pullRequestDetails Details of the pull request
-   * @param existingLabels List of labels already in the repository
-   * @returns Array of label suggestions
+   * Suggests labels and description for a pull request based on its content
    */
-  async suggestLabels(
+  async suggestPRContent(
     pullRequestDetails: PullRequestDetails,
-    existingLabels: GithubLabel[]
-  ): Promise<LabelSuggestion[]> {
+    existingLabels: GithubLabel[],
+    prTemplate?: string
+  ): Promise<PRSuggestion> {
     if (!this.client) {
       throw new PublicError(
         'OpenAI API key not found. Please set the OPENAI_API_KEY environment variable.'
@@ -73,59 +85,72 @@ ${fileChanges}
 
     try {
       const prSummary = this.generatePRSummary(pullRequestDetails);
-
-      //? Extract existing label names and descriptions
       const existingLabelInfo = existingLabels
         .map(label => `${label.name}: ${label.description || 'No description'}`)
         .join('\n');
 
-      // Create a Zod schema for label suggestions
-      const labelSuggestionSchema = z.object({
-        name: z.string().describe('The name of the suggested label'),
-        description: z.string().describe('Description of why this label is appropriate for the PR'),
-        confidence: z.number().describe('Confidence score between 1-100'),
-        isNew: z
-          .boolean()
-          .describe('Whether this is a new label (true) or exists in the repository (false)'),
-      });
+      const prompt = this.getPRSuggestionPrompt(prSummary, existingLabelInfo, prTemplate);
 
-      // Define the schema for multiple suggestions
-      const suggestionsSchema = z.object({
-        suggestions: z
-          .array(labelSuggestionSchema)
-          .describe('Array of label suggestions for the pull request'),
-      });
-
-      const prompt = getLabelSuggestionPrompt(prSummary, existingLabelInfo);
-
-      const completion = await this.client.beta.chat.completions.parse({
-        model: 'gpt-4o',
+      const completion = await this.client.chat.completions.create({
+        model: 'gpt-4-turbo-preview',
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.3,
-        response_format: zodResponseFormat(suggestionsSchema, 'labelSuggestions'),
+        response_format: { type: 'json_object' },
+        seed: 42,
       });
 
-      // Get the parsed data which is already validated against our schema
-      const result = completion.choices[0].message.parsed;
+      const result = JSON.parse(completion.choices[0].message.content || '{}') as {
+        labels: Array<{
+          name: string;
+          description: string;
+          confidence: number;
+          isNew: boolean;
+        }>;
+        description: {
+          en: {
+            content: string;
+            confidence: number;
+          };
+          pl: {
+            content: string;
+            confidence: number;
+          };
+        };
+      };
 
-      if (!result || !result.suggestions) {
-        throw new PublicError('Failed to get label suggestions from OpenAI');
+      if (
+        !result ||
+        !result.labels ||
+        !result.description ||
+        !result.description.en ||
+        !result.description.pl
+      ) {
+        throw new PublicError('Failed to get suggestions from OpenAI');
       }
 
-      // Validate and normalize the results
-      return result.suggestions.map(suggestion => ({
-        name: suggestion.name,
-        description: suggestion.description,
-        // Ensure confidence is within the valid range
-        confidence: Math.min(Math.max(1, suggestion.confidence), 100),
-        isNew: suggestion.isNew,
-      }));
+      return {
+        labels: result.labels.map(label => ({
+          name: label.name,
+          description: label.description,
+          confidence: Math.min(Math.max(1, label.confidence), 100),
+          isNew: label.isNew,
+        })),
+        description: {
+          en: {
+            content: result.description.en.content,
+            confidence: Math.min(Math.max(1, result.description.en.confidence), 100),
+          },
+          pl: {
+            content: result.description.pl.content,
+            confidence: Math.min(Math.max(1, result.description.pl.confidence), 100),
+          },
+        },
+      };
     } catch (error) {
       if (error instanceof PublicError) {
         throw error;
       }
 
-      // Obsługa błędów związanych z limitami żądań
       if (error instanceof Error && error.message.includes('rate limit')) {
         logger.error(`Rate limit exceeded: ${error.message}`);
         throw new RateLimitError(
@@ -133,7 +158,6 @@ ${fileChanges}
         );
       }
 
-      // Ogólne błędy OpenAI
       logger.error(
         `OpenAI API request failed: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
@@ -141,6 +165,66 @@ ${fileChanges}
         `Błąd usługi AI: ${error instanceof Error ? error.message : 'Nieznany błąd'}`
       );
     }
+  }
+
+  private getPRSuggestionPrompt(
+    prSummary: string,
+    existingLabels: string,
+    prTemplate?: string
+  ): string {
+    const templateInstructions = prTemplate
+      ? `\nThe repository uses the following pull request template:
+${prTemplate}
+
+Please ensure the generated description follows this template structure while maintaining a clear and concise format.`
+      : '';
+
+    return `
+      You are a GitHub pull request assistant. Your task is to suggest appropriate labels and a description for a pull request based on its content.
+
+      Here's information about the pull request:
+      ${prSummary}
+
+      These are the labels available in the repository:
+      ${existingLabels}
+
+      Based on the pull request content:
+      1. Suggest the most relevant labels from the available ones or suggest new ones if needed
+      2. Generate comprehensive descriptions in both English and Polish that follow the Conventional Commits specification and summarize the changes
+
+      The descriptions should:
+      - Start with a type (feat, fix, docs, style, refactor, perf, test, or chore)
+      - Include a scope if applicable
+      - Have a clear and concise description
+      - List the main changes and their impact
+      - Reference any related issues${templateInstructions}
+
+      Format your response as a JSON object with:
+      1. A 'labels' array containing label suggestions (name, description, confidence, isNew)
+      2. A 'description' object with English and Polish versions, each containing content and confidence score
+
+      Example:
+      {
+        "labels": [
+          {
+            "name": "feature",
+            "description": "This PR adds a new feature",
+            "confidence": 90,
+            "isNew": false
+          }
+        ],
+        "description": {
+          "en": {
+            "content": "feat(auth): implement OAuth2 authentication\\n\\nAdd OAuth2 authentication support with the following changes:\\n- Integrate OAuth2 provider\\n- Add user authentication flow\\n- Implement token refresh mechanism\\n\\nFixes #123",
+            "confidence": 85
+          },
+          "pl": {
+            "content": "feat(auth): implementacja uwierzytelniania OAuth2\\n\\nDodano obsługę uwierzytelniania OAuth2 z następującymi zmianami:\\n- Integracja z dostawcą OAuth2\\n- Dodanie przepływu uwierzytelniania użytkownika\\n- Implementacja mechanizmu odświeżania tokenów\\n\\nNaprawia #123",
+            "confidence": 85
+          }
+        }
+      }
+    `;
   }
 }
 

--- a/src/schemas/pr-suggestions.ts
+++ b/src/schemas/pr-suggestions.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const labelSuggestionSchema = z.object({
+  name: z.string().describe('The name of the suggested label'),
+  description: z.string().describe('Description of why this label is appropriate for the PR'),
+  confidence: z.number().describe('Confidence score between 1-100'),
+  isNew: z
+    .boolean()
+    .describe('Whether this is a new label (true) or exists in the repository (false)'),
+});
+
+export const descriptionSchema = z.object({
+  content: z.string().describe('Suggested description for the pull request'),
+  confidence: z.number().describe('Confidence score between 1-100 for the suggested description'),
+});
+
+export const prSuggestionSchema = z.object({
+  labels: z
+    .array(labelSuggestionSchema)
+    .describe('Array of label suggestions for the pull request'),
+  description: z
+    .object({
+      en: descriptionSchema.describe('English version of the description'),
+      pl: descriptionSchema.describe('Polish version of the description'),
+    })
+    .describe('Multilingual descriptions for the pull request'),
+});


### PR DESCRIPTION
- Updated the `suggest-labels` function to suggest not only labels but also descriptions for pull requests, which increases documentation efficiency.
- Added support for pull request templates, allowing for better customization of generated descriptions.
- Updated documentation in README and interactive guide to reflect new capabilities.
- Improved pull request content analysis logic to generate more comprehensive suggestions.
